### PR TITLE
enable feature: encoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["parser-implementations"]
 include = ["src/*", "Cargo.toml", "LICENSE-MIT", "LICENSE-APACHE", "README.md"]
 
 [dependencies]
-quick-xml = "0.17"
+quick-xml = { version = "0.17", features = ["encoding"] }
 derive_builder = "0.9"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 failure = "0.1"

--- a/src/extension/util.rs
+++ b/src/extension/util.rs
@@ -87,13 +87,13 @@ fn parse_extension_element<R: BufRead>(
                 items.push(ext);
             }
             Event::CData(element) => {
-                extension.value = Some(reader.decode(&element)?.into());
+                extension.value = Some(reader.decode(&element).into());
             }
             Event::Text(element) => {
                 extension.value = Some(element.unescape_and_decode(reader)?.trim().to_string());
             }
             Event::End(element) => {
-                extension.name = reader.decode(element.name())?.into();
+                extension.name = reader.decode(element.name()).into();
                 break;
             }
             Event::Eof => return Err(Error::Eof),

--- a/src/util.rs
+++ b/src/util.rs
@@ -41,7 +41,7 @@ pub fn atom_text<B: BufRead>(reader: &mut Reader<B>) -> Result<Option<String>, E
                 }
                 depth -= 1;
                 result.push_str("</");
-                result.push_str(&reader.decode(end.name())?);
+                result.push_str(&reader.decode(end.name()));
                 result.push('>');
             }
             Event::Empty(start) => {
@@ -51,7 +51,7 @@ pub fn atom_text<B: BufRead>(reader: &mut Reader<B>) -> Result<Option<String>, E
                 result.push_str("/>");
             }
             Event::CData(text) => {
-                let decoded = reader.decode(text.escaped())?;
+                let decoded = reader.decode(text.escaped());
                 result.push_str(&decoded);
             }
             Event::Text(text) => {
@@ -95,7 +95,7 @@ pub fn atom_xhtml<B: BufRead>(reader: &mut Reader<B>) -> Result<Option<String>, 
                 }
                 depth -= 1;
                 result.push_str("</");
-                result.push_str(&reader.decode(end.name())?);
+                result.push_str(&reader.decode(end.name()));
                 result.push('>');
             }
             Event::Empty(start) => {
@@ -105,11 +105,11 @@ pub fn atom_xhtml<B: BufRead>(reader: &mut Reader<B>) -> Result<Option<String>, 
                 result.push_str("/>");
             }
             Event::CData(text) => {
-                let decoded = reader.decode(text.escaped())?;
+                let decoded = reader.decode(text.escaped());
                 result.push_str(&decoded);
             }
             Event::Text(text) => {
-                let decoded = reader.decode(text.escaped())?;
+                let decoded = reader.decode(text.escaped());
                 result.push_str(&decoded);
             }
             Event::Comment(text) => {


### PR DESCRIPTION
enable feature: encoding

Here is a breakchange, now, `quick-xml` only support UTF-8 by default.

ref: https://github.com/tafia/quick-xml/blob/master/Changelog.md#0160